### PR TITLE
Create image on docker hub

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,0 +1,39 @@
+
+name: Container
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-docker-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate tag name
+        run: |
+            if [[ "${{ github.repository_owner }}" != "sogno-platform" ]];
+            then
+                echo "TAG_NAME=sogno/file-service:${{ github.repository_owner }}" >> $GITHUB_ENV
+            else
+                echo "TAG_NAME=sogno/file-service" >> $GITHUB_ENV
+            fi
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_SECRET }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+         context: .
+         file: Dockerfile
+         push: true
+         tags: "${{ env.TAG_NAME }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+
+FROM golang:latest
+
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+COPY main.go go.mod /usr/src/app/
+COPY routes /usr/src/app/routes/
+COPY config /usr/src/app/config/
+COPY docs /usr/src/app/docs/
+COPY api /usr/src/app/api/
+COPY file /usr/src/app/file/
+RUN mkdir -p /usr/src/app/.config/sogno-file-service
+COPY minio.config /usr/src/app/.config/sogno-file-service/config.json
+RUN go mod tidy
+RUN go build
+RUN useradd app -d /usr/src/app
+RUN chown app -R /usr/src/app
+USER app
+
+EXPOSE 8080
+
+CMD go run main.go
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ $ go mod tidy
 $ go build
 ```
 
+### Docker build / run
+
+The docker build uses the file "minio.config" to store the s3 details.
+You will need to make sure this matches your setup.
+
+```bash
+$ docker build -t sogno-file-service .
+$ docker run -p 8080:8080 sogno-file-service
+```
+
 ### Generating OpenAPI docs
 
 ```bash

--- a/file/file_minio.go
+++ b/file/file_minio.go
@@ -34,7 +34,7 @@ func NewMinIOClient(endpoint string) (*MinIOClient, error) {
 	)
 	client, err := minio.New(endpoint, &minio.Options{
 		Creds:  creds,
-		Secure: true,
+		Secure: false, // TODO: generate certificates and enable https
 	})
 	return &MinIOClient{Client: client}, err
 }
@@ -47,7 +47,7 @@ func (c *MinIOClient) PutObject(bucket string, key string, content io.Reader, co
 		key,
 		content,
 		contentSize,
-		minio.PutObjectOptions{ContentType: contentType},
+		minio.PutObjectOptions{ContentType: contentType, ContentDisposition: "filename=" + key + ".zip"},
 	)
 	return err
 }

--- a/minio.config
+++ b/minio.config
@@ -1,0 +1,4 @@
+{
+  "minio_endpoint": "minio:9000",
+  "minio_bucket": "sogno-platform"
+}


### PR DESCRIPTION
This PR adds a dockerfile, which includes all dependencies required by the file-service. This is required for the simulation demo in example-deployments. HTTPS is not used for the demo yet. Issue #3 follows up on this.